### PR TITLE
Disable ignoring rest order when geopoint's near is enabled.

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -903,7 +903,7 @@ function hasNearFilter(where) {
   searchForNear(where);
 
   function found(prop) {
-    return prop && prop.near;
+    return prop && prop.near && !prop.ignore;
   }
 
   function searchForNear(node) {


### PR DESCRIPTION
### Description
Now it's possible to add `ingore` flag to `geopoint` field in `where` clause to disable ignoring rest order options.
